### PR TITLE
docs: server mode documentation and deploy scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,65 @@ Behavior:
 - The CLI opens a secure modal in the app instead of reading the secret in the terminal.
 - The CLI prints only redacted results such as `created OPENAI_API_KEY for demo-project`.
 
+## Server Mode (Headless)
+
+The Controller can run as a standalone HTTP/WebSocket server for headless Linux deployments — no desktop or display required. The same Svelte UI is served as static files and accessed via a web browser.
+
+### Build
+
+```bash
+pnpm build                                              # Vite frontend → dist/
+cd src-tauri && cargo build --release --features server  # Axum server binary
+```
+
+### Run
+
+```bash
+CONTROLLER_DIST_DIR=../dist \
+CONTROLLER_AUTH_TOKEN=mysecret \
+./src-tauri/target/release/server
+```
+
+Then open `http://<host>:3001?token=mysecret` in a browser.
+
+### Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `CONTROLLER_PORT` | `3001` | HTTP listen port |
+| `CONTROLLER_BIND` | `0.0.0.0` | Bind address |
+| `CONTROLLER_AUTH_TOKEN` | *(none)* | Bearer token for API/WS auth. If unset, no auth is enforced. |
+| `CONTROLLER_DIST_DIR` | `./dist` (relative to binary) | Path to the Vite-built `dist/` directory |
+| `CONTROLLER_SOCKET` | `/tmp/the-controller.sock` | Unix socket for session status hooks |
+
+### Architecture
+
+- `src-tauri/src/bin/server.rs` — Axum HTTP + WebSocket server with 40+ API routes
+- `src/lib/backend.ts` — detects `__TAURI_INTERNALS__` and routes commands to Tauri IPC (desktop) or `fetch`/WebSocket (browser)
+- `src-tauri/src/emitter.rs` — `WsBroadcastEmitter` pushes events over WebSocket instead of Tauri events
+- `src/lib/platform.ts` — lazy-loads Tauri-only imports (`openUrl`, clipboard) with browser fallbacks
+
+Desktop-only features (clipboard image copy, app screenshot, voice pipeline) return stubs in server mode.
+
+### Deploy to a Linux Server
+
+The server runs directly on the host (not in a container) because sessions need access to host projects and tools like `claude`, `git`, `tmux`.
+
+```bash
+# Build, install to ~/.the-controller, set up user systemd + optional Caddy HTTPS
+./deploy/deploy.sh --host controller.example.com
+```
+
+The script handles: build, install, auth token generation, user-level systemd unit, and optional Caddy reverse proxy. No sudo needed for the service itself. See `deploy/` for the reference systemd unit and Caddyfile.
+
+```bash
+# Manage the service
+systemctl --user status the-controller
+journalctl --user -u the-controller -f
+
+# Config lives at ~/.the-controller/server.env
+```
+
 ## Navigation & Features
 
 ### Switch Focus `esc` `l`
@@ -118,7 +177,7 @@ Not sure what a feature does or how something works? Just ask Claude. The defaul
 Or browse the docs directly:
 
 - [Keyboard Shortcuts & Modes](docs/keyboard-modes.md) — all hotkeys, workspace modes, and how to stage/preview changes
-- [Domain Knowledge](docs/domain-knowledge.md) — hard-won lessons about Tauri, tmux, and session architecture
+- [Domain Knowledge](docs/domain-knowledge.md) — hard-won lessons about Tauri, tmux, session architecture, and server mode
 - [Demo Recording](docs/demo.md) — how to record demos of The Controller
 
 ## Caveats

--- a/deploy/Caddyfile
+++ b/deploy/Caddyfile
@@ -1,0 +1,84 @@
+# The Controller — reverse proxy with automatic HTTPS
+#
+# Replace controller.example.com with your domain.
+# Caddy handles TLS certificates automatically via Let's Encrypt.
+#
+# Install:
+#   sudo cp deploy/Caddyfile /etc/caddy/Caddyfile
+#   sudo systemctl reload caddy
+
+controller.example.com {
+	# ─── TLS ─────────────────────────────────────────────────────────
+	tls {
+		protocols tls1.2 tls1.3
+		ciphers TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384 TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256 TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256 TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+	}
+
+	# ─── Static asset caching ────────────────────────────────────────
+	# Vite hashed assets can be cached indefinitely
+	@static {
+		path /assets/*
+		path /favicon.ico
+	}
+	header @static {
+		Cache-Control "public, max-age=31536000, immutable"
+		-Pragma
+		-Expires
+	}
+
+	# ─── Reverse proxy ───────────────────────────────────────────────
+	reverse_proxy localhost:3001 {
+		# Pass real client info to the backend
+		header_up X-Real-IP {remote_host}
+		header_up X-Forwarded-For {remote_host}
+		header_up X-Forwarded-Proto {scheme}
+		header_up X-Forwarded-Host {host}
+
+		# WebSocket support (xterm.js + event stream)
+		# Caddy handles this automatically, but explicit timeouts help
+		transport http {
+			keepalive 120s
+			keepalive_idle_conns 64
+		}
+
+		# Retry on transient failures
+		fail_duration 30s
+		max_fails 3
+		unhealthy_status 502 503 504
+	}
+
+	# ─── Compression ─────────────────────────────────────────────────
+	encode {
+		zstd
+		gzip 6
+		minimum_length 256
+		match {
+			header Content-Type text/*
+			header Content-Type application/json*
+			header Content-Type application/javascript*
+			header Content-Type application/xml*
+			header Content-Type image/svg+xml*
+		}
+	}
+
+	# ─── Request limits ──────────────────────────────────────────────
+	request_body {
+		max_size 50MB
+	}
+
+	# ─── Logging ─────────────────────────────────────────────────────
+	log {
+		output file /var/log/caddy/the-controller.log {
+			roll_size 50mb
+			roll_keep 5
+			roll_keep_for 720h
+		}
+		format json
+		level INFO
+	}
+
+	# ─── Error handling ──────────────────────────────────────────────
+	handle_errors {
+		respond "{err.status_code} {err.status_text}"
+	}
+}

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Deploy The Controller server mode on a Linux host.
+# Uses user-level systemd — no sudo for the service itself.
+#
+# Usage: ./deploy.sh [--port 3001] [--host controller.example.com]
+#
+# Prerequisites: Rust toolchain, Node.js + pnpm, tmux, git
+# Optional: Caddy (for HTTPS reverse proxy)
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+INSTALL_DIR="$HOME/.the-controller"
+PORT="${CONTROLLER_PORT:-3001}"
+HOST=""
+SKIP_BUILD=false
+
+usage() {
+  echo "Usage: $0 [OPTIONS]"
+  echo ""
+  echo "Options:"
+  echo "  --port PORT       Server port (default: 3001)"
+  echo "  --host DOMAIN     Domain for Caddy HTTPS proxy (optional)"
+  echo "  --skip-build      Skip build step (use existing binaries)"
+  echo "  -h, --help        Show this help"
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    --port) PORT="$2"; shift 2 ;;
+    --host) HOST="$2"; shift 2 ;;
+    --skip-build) SKIP_BUILD=true; shift ;;
+    -h|--help) usage ;;
+    *) echo "Unknown option: $1"; usage ;;
+  esac
+done
+
+echo "==> Deploying The Controller"
+echo "    Install dir: $INSTALL_DIR"
+echo "    Port: $PORT"
+[[ -n "$HOST" ]] && echo "    Host: $HOST (Caddy HTTPS)"
+
+# ── Check prerequisites ─────────────────────────────────────────────
+check_cmd() {
+  if ! command -v "$1" &>/dev/null; then
+    echo "Error: $1 is required but not found."
+    exit 1
+  fi
+}
+
+check_cmd tmux
+check_cmd git
+
+if [[ "$SKIP_BUILD" == false ]]; then
+  check_cmd rustc
+  check_cmd cargo
+  check_cmd node
+  check_cmd pnpm
+fi
+
+# ── Build ────────────────────────────────────────────────────────────
+if [[ "$SKIP_BUILD" == false ]]; then
+  echo "==> Building frontend..."
+  cd "$REPO_ROOT"
+  pnpm install --frozen-lockfile
+  pnpm build
+
+  echo "==> Building server binary..."
+  cd "$REPO_ROOT/src-tauri"
+  cargo build --release --features server --bin server
+fi
+
+# ── Install ──────────────────────────────────────────────────────────
+echo "==> Installing to $INSTALL_DIR..."
+mkdir -p "$INSTALL_DIR/dist"
+cp "$REPO_ROOT/src-tauri/target/release/server" "$INSTALL_DIR/server"
+cp -r "$REPO_ROOT/dist/." "$INSTALL_DIR/dist/"
+
+# ── Generate auth token if not set ───────────────────────────────────
+ENV_FILE="$INSTALL_DIR/server.env"
+if [[ ! -f "$ENV_FILE" ]]; then
+  TOKEN=$(openssl rand -hex 24)
+  cat > "$ENV_FILE" <<EOF
+CONTROLLER_AUTH_TOKEN=$TOKEN
+CONTROLLER_PORT=$PORT
+CONTROLLER_BIND=127.0.0.1
+CONTROLLER_DIST_DIR=$INSTALL_DIR/dist
+EOF
+  chmod 600 "$ENV_FILE"
+  echo "==> Generated auth token in $ENV_FILE"
+else
+  echo "==> Keeping existing $ENV_FILE"
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  TOKEN="${CONTROLLER_AUTH_TOKEN:-}"
+fi
+
+# ── Install user-level systemd unit ──────────────────────────────────
+echo "==> Installing user systemd service..."
+mkdir -p "$HOME/.config/systemd/user"
+cp "$REPO_ROOT/deploy/the-controller.service" "$HOME/.config/systemd/user/"
+systemctl --user daemon-reload
+systemctl --user enable --now the-controller
+
+# Enable lingering so the service survives logout
+if command -v loginctl &>/dev/null; then
+  loginctl enable-linger "$USER" 2>/dev/null || true
+fi
+
+echo "==> Service started: systemctl --user status the-controller"
+
+# ── Caddy reverse proxy (optional) ──────────────────────────────────
+if [[ -n "$HOST" ]]; then
+  if ! command -v caddy &>/dev/null; then
+    echo ""
+    echo "Warning: --host specified but caddy is not installed. Skipping."
+    echo "Install Caddy: https://caddyserver.com/docs/install"
+    echo "Then copy deploy/Caddyfile to /etc/caddy/Caddyfile and edit the domain."
+  else
+    echo "==> Configuring Caddy for $HOST..."
+    CADDY_FILE="/etc/caddy/Caddyfile"
+
+    # Generate a site-specific Caddyfile from the template
+    CADDY_SNIPPET=$(sed \
+      -e "s/controller\.example\.com/$HOST/g" \
+      -e "s/localhost:3001/localhost:$PORT/g" \
+      "$REPO_ROOT/deploy/Caddyfile")
+
+    if [[ -f "$CADDY_FILE" ]] && grep -q "$HOST" "$CADDY_FILE"; then
+      echo "    Caddy config for $HOST already exists, skipping."
+      echo "    Edit $CADDY_FILE manually if needed."
+    else
+      echo "$CADDY_SNIPPET" | sudo tee -a "$CADDY_FILE" > /dev/null
+      sudo systemctl reload caddy
+      echo "    Caddy configured: https://$HOST"
+    fi
+  fi
+fi
+
+# ── Print access info ────────────────────────────────────────────────
+# shellcheck disable=SC1090
+source "$ENV_FILE"
+TOKEN="${CONTROLLER_AUTH_TOKEN:-}"
+
+echo ""
+echo "==> Deployment complete!"
+if [[ -n "$HOST" ]] && command -v caddy &>/dev/null; then
+  echo "    URL: https://$HOST?token=$TOKEN"
+else
+  echo "    URL: http://localhost:$PORT?token=$TOKEN"
+fi
+echo ""
+echo "    Manage:  systemctl --user {start|stop|restart|status} the-controller"
+echo "    Logs:    journalctl --user -u the-controller -f"
+echo "    Config:  $ENV_FILE"

--- a/deploy/the-controller.service
+++ b/deploy/the-controller.service
@@ -1,0 +1,27 @@
+# User-level systemd unit for The Controller server mode.
+#
+# Install:
+#   mkdir -p ~/.config/systemd/user
+#   cp deploy/the-controller.service ~/.config/systemd/user/
+#   systemctl --user daemon-reload
+#   systemctl --user enable --now the-controller
+#
+# The service runs as your user — no sudo, no permission conflicts.
+# Requires lingering so it survives logout:
+#   loginctl enable-linger $USER
+
+[Unit]
+Description=The Controller - Claude Code Session Manager
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=%h/.the-controller
+EnvironmentFile=%h/.the-controller/server.env
+ExecStart=%h/.the-controller/server
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target

--- a/docs/domain-knowledge.md
+++ b/docs/domain-knowledge.md
@@ -88,3 +88,30 @@ Session status (idle/working/exited) is detected using Claude Code hooks, not PT
 - Hook commands use `nc -w 2` + `; true` to avoid blocking Claude Code (`timeout` is not available on macOS)
 - Stale socket files are cleaned up on startup
 - Reattached tmux sessions default to "idle" until the next hook fires
+
+## Server Mode (Headless Browser Deployment)
+
+The Controller can run without a desktop environment as a standalone Axum HTTP/WebSocket server (`src-tauri/src/bin/server.rs`). The Vite-built frontend is served as static files and accessed via a web browser.
+
+**How it works:**
+- The `server` Cargo feature gates `axum` and `tower-http` dependencies. The server binary lives at `src/bin/server.rs` with `required-features = ["server"]`.
+- `src/lib/backend.ts` checks for `__TAURI_INTERNALS__` at load time. In desktop mode, commands go through Tauri IPC; in browser mode, they become `POST /api/{command}` requests and events flow over a shared WebSocket at `/ws`.
+- `src-tauri/src/emitter.rs` defines an `EventEmitter` trait with three implementations: `TauriEmitter` (desktop), `WsBroadcastEmitter` (server), and `NoopEmitter` (tests).
+- `status_socket.rs` exposes `start_listener_with_state(Arc<AppState>)` so the server binary can receive Claude Code session hooks without a Tauri `AppHandle`.
+
+**Auth:**
+- Optional bearer token via `CONTROLLER_AUTH_TOKEN` env var.
+- Token is passed as a URL query param (`?token=...`) on first load, moved to `sessionStorage`, and stripped from the URL to avoid leaking via history/referrer.
+- WebSocket auth uses the same token as a query param.
+- Auth middleware skips static file requests; only `/api/*` and `/ws` are gated.
+
+**Desktop-only stubs:** `copy_image_file_to_clipboard`, `capture_app_screenshot`, `start_voice_pipeline`, `stop_voice_pipeline` return errors in server mode since they require native hardware access.
+
+**Graceful shutdown:** The server handles `SIGTERM`/`SIGINT` by cleaning up the Unix domain socket and killing all PTY/tmux sessions.
+
+**Key files:**
+- `src-tauri/src/bin/server.rs` — Axum server (~2800 lines, 40+ routes)
+- `src/lib/backend.ts` — dual-mode command/event routing
+- `src/lib/platform.ts` — lazy Tauri imports with browser fallbacks
+- `src-tauri/src/emitter.rs` — EventEmitter trait + implementations
+- `src-tauri/src/status_socket.rs` — decoupled from AppHandle for server use


### PR DESCRIPTION
## What

Document the headless server mode and add production deploy tooling.

## Changes

- **README.md** — new "Server Mode (Headless)" section with build/run instructions, env var reference, architecture overview, and deploy guide
- **docs/domain-knowledge.md** — new section covering dual-mode routing, auth model, emitter trait, graceful shutdown, and key files
- **deploy/deploy.sh** — one-click deploy script: builds, installs to `~/.the-controller`, generates auth token, sets up user-level systemd, optionally configures Caddy HTTPS
- **deploy/the-controller.service** — user-level systemd unit (no sudo, no permission conflicts, `loginctl enable-linger` for persistence)
- **deploy/Caddyfile** — production reverse proxy config with TLS hardening, static asset caching, zstd/gzip compression, request size limits, rolling JSON logs