### PR TITLE
feat: add dev:app and dev:server npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "check": "svelte-check --tsconfig ./tsconfig.json",
+    "dev:app": "pnpm build && cd src-tauri && cargo run",
+    "dev:server": "pnpm build && cd src-tauri && CONTROLLER_DIST_DIR=../dist cargo run --features server --bin server",
     "tauri": "tauri",
     "test": "vitest run",
     "test:e2e": "playwright test --project=e2e",


### PR DESCRIPTION
## What

Add two new npm scripts to split dev workflows:

- `pnpm dev:app` — builds frontend with Vite, then runs the Tauri binary directly via `cargo run`. No dev server, no port 1420/1421.
- `pnpm dev:server` — builds frontend, then runs the server binary with `CONTROLLER_DIST_DIR=../dist`. Server prints a ready-to-use URL on startup.

## Why

`pnpm tauri dev` starts a Vite dev server on port 1420 (+ HMR on 1421). The new commands provide port-free app mode and a server mode with a usable URL, while keeping the existing HMR workflow intact.

## Testing

- All 315 frontend tests pass
- All 17 Rust tests pass
- `cargo clippy`, `cargo fmt --check`, `pnpm check` all clean