### PR TITLE
fix: eliminate PTY broker race conditions

### DIFF
--- a/src-tauri/src/bin/pty_broker.rs
+++ b/src-tauri/src/bin/pty_broker.rs
@@ -1,6 +1,7 @@
 use portable_pty::{native_pty_system, CommandBuilder, MasterPty, PtySize};
 use std::collections::HashMap;
 use std::io::{Read as _, Write};
+use std::os::unix::io::AsRawFd;
 use std::path::PathBuf;
 use std::sync::Arc;
 use the_controller_lib::broker_protocol::*;
@@ -87,6 +88,10 @@ impl Broker {
 
     fn pid_file_path(&self) -> PathBuf {
         self.socket_dir.join("pty-broker.pid")
+    }
+
+    fn lock_file_path(&self) -> PathBuf {
+        self.socket_dir.join("pty-broker.lock")
     }
 
     async fn handle_spawn(&self, req: SpawnRequest) -> Response {
@@ -334,6 +339,7 @@ impl Broker {
     fn cleanup(&self) {
         let _ = std::fs::remove_file(self.control_socket_path());
         let _ = std::fs::remove_file(self.pid_file_path());
+        let _ = std::fs::remove_file(self.lock_file_path());
     }
 }
 
@@ -478,6 +484,28 @@ fn main() {
 async fn async_main(socket_dir: PathBuf) {
     let broker = Arc::new(Broker::new(socket_dir));
 
+    // Acquire exclusive lock file — prevents multiple brokers from running.
+    // The fd is held for the broker's entire lifetime; the OS releases it on exit/crash.
+    let lock_file = match std::fs::OpenOptions::new()
+        .create(true)
+        .write(true)
+        .truncate(false)
+        .open(broker.lock_file_path())
+    {
+        Ok(f) => f,
+        Err(e) => {
+            eprintln!("failed to open lock file: {}", e);
+            std::process::exit(1);
+        }
+    };
+    let lock_ret = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+    if lock_ret != 0 {
+        // Another broker already holds the lock — exit silently.
+        std::process::exit(0);
+    }
+    // Keep _lock_file alive (held open) for the broker's entire lifetime.
+    let _lock_file = lock_file;
+
     // Write PID file
     let pid = std::process::id();
     if let Err(e) = std::fs::write(broker.pid_file_path(), pid.to_string()) {
@@ -551,11 +579,14 @@ async fn handle_control_client(mut stream: UnixStream, broker: Arc<Broker>, shut
         };
 
         if let Request::Shutdown = &req {
+            // Notify shutdown FIRST so the main accept loop stops before
+            // the client receives the response — prevents new connections
+            // from arriving between response and shutdown.
+            shutdown.notify_one();
             let resp = Response::Ok(OkResponse {
                 session_id: Uuid::nil(),
             });
             let _ = send_response(&mut stream, &resp).await;
-            shutdown.notify_one();
             break;
         }
 

--- a/src-tauri/src/broker_client.rs
+++ b/src-tauri/src/broker_client.rs
@@ -1,5 +1,6 @@
 use crate::broker_protocol::*;
 use std::io::{self, Read, Write};
+use std::os::unix::io::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -40,6 +41,10 @@ impl BrokerClient {
         self.socket_dir.join("pty-broker.pid")
     }
 
+    fn lock_file_path(&self) -> PathBuf {
+        self.socket_dir.join("pty-broker.lock")
+    }
+
     fn broker_binary_path() -> Option<PathBuf> {
         crate::cli_install::controller_bin_dir().map(|d| d.join("pty-broker"))
     }
@@ -64,11 +69,20 @@ impl BrokerClient {
         if let Ok(stream) = UnixStream::connect(&path) {
             // Check if the running broker is stale
             if self.is_broker_stale() {
+                let old_pid = self.read_pid();
                 // Shut down the stale broker (best-effort)
                 let _ = self.send_shutdown_to(&stream);
                 drop(stream);
-                // Wait briefly for it to exit
-                std::thread::sleep(std::time::Duration::from_millis(200));
+                // Wait for the old process to actually exit
+                if let Some(pid) = old_pid {
+                    if !self.wait_for_pid_exit(pid, std::time::Duration::from_secs(3)) {
+                        // Escalate to SIGKILL if graceful shutdown didn't work
+                        unsafe {
+                            libc::kill(pid, libc::SIGKILL);
+                        }
+                        self.wait_for_pid_exit(pid, std::time::Duration::from_millis(500));
+                    }
+                }
                 self.cleanup_stale_pid();
             } else {
                 return Ok(stream);
@@ -93,6 +107,26 @@ impl BrokerClient {
             io::ErrorKind::ConnectionRefused,
             "failed to connect to broker after spawning",
         ))
+    }
+
+    /// Read the PID from the PID file, if it exists and is valid.
+    fn read_pid(&self) -> Option<i32> {
+        let contents = std::fs::read_to_string(self.pid_file_path()).ok()?;
+        contents.trim().parse::<i32>().ok()
+    }
+
+    /// Poll until a process exits or the timeout expires. Returns true if the process exited.
+    fn wait_for_pid_exit(&self, pid: i32, timeout: std::time::Duration) -> bool {
+        let start = std::time::Instant::now();
+        let poll_interval = std::time::Duration::from_millis(50);
+        while start.elapsed() < timeout {
+            let alive = unsafe { libc::kill(pid, 0) } == 0;
+            if !alive {
+                return true;
+            }
+            std::thread::sleep(poll_interval);
+        }
+        false
     }
 
     /// Check if the PID file points to a dead process and clean up if so.
@@ -141,6 +175,7 @@ impl BrokerClient {
     }
 
     /// Spawn the broker binary as a daemon.
+    /// Uses a lock file to prevent multiple concurrent spawns.
     fn spawn_broker(&self) -> io::Result<()> {
         let binary = Self::broker_binary_path().ok_or_else(|| {
             io::Error::new(io::ErrorKind::NotFound, "pty-broker binary not found")
@@ -155,6 +190,24 @@ impl BrokerClient {
 
         let _ = std::fs::create_dir_all(&self.socket_dir);
 
+        // Try to acquire the lock file non-blocking. If another broker (or spawner)
+        // already holds it, skip spawning — the retry loop in connect_control()
+        // will wait for the existing broker to become ready.
+        let lock_file = std::fs::OpenOptions::new()
+            .create(true)
+            .write(true)
+            .truncate(false)
+            .open(self.lock_file_path())?;
+        let lock_ret = unsafe { libc::flock(lock_file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) };
+        if lock_ret != 0 {
+            // Lock is held — another broker is already starting or running.
+            // Drop the fd and let the connect retry loop handle it.
+            return Ok(());
+        }
+        // We hold the lock briefly to prevent concurrent spawns.
+        // The broker process itself will acquire the lock on startup,
+        // so we release ours immediately after spawning.
+
         std::process::Command::new(&binary)
             .arg("--socket-dir")
             .arg(&self.socket_dir)
@@ -162,6 +215,9 @@ impl BrokerClient {
             .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
             .spawn()?;
+
+        // Drop the lock file fd — the broker will acquire its own lock.
+        drop(lock_file);
 
         Ok(())
     }


### PR DESCRIPTION
## Problem

Multiple race conditions in the PTY broker lifecycle:

1. **Orphan broker**: When replacing a stale broker (different build date), the old process wasn't guaranteed to exit before the new one spawned. The fixed 200ms sleep was insufficient — the old broker could linger, and once the new broker overwrote the PID file, the old one became an untracked orphan.

2. **Multiple brokers**: Two app instances discovering a missing broker simultaneously could both call `spawn_broker()`, briefly running two broker daemons.

3. **Shutdown window**: Between sending the shutdown Ok response and the broker actually stopping its accept loop, new connections could sneak in and get orphaned.

## Fix

- **Wait for actual exit**: Read the old broker's PID before sending shutdown, then poll `kill(pid, 0)` until it dies (up to 3s), escalating to SIGKILL if needed.
- **Lock file**: Both the broker and the client use `flock(LOCK_EX | LOCK_NB)` on `pty-broker.lock`. The broker holds the lock for its lifetime (auto-released on crash). The client skips spawning if the lock is already held.
- **Shutdown ordering**: `shutdown.notify_one()` now fires before sending the Ok response, so the accept loop exits before the client even receives the reply.