### PR TITLE
fix: expose server deploy and keybinding routes

### DIFF
--- a/docs/plans/2026-03-17-server-api-parity-design.md
+++ b/docs/plans/2026-03-17-server-api-parity-design.md
@@ -1,0 +1,32 @@
+# Server API Parity Design
+
+## Definition
+
+Expose the deploy and keybinding commands in server mode so the browser frontend can call the same backend surface as the desktop Tauri app. The issue exists because `src-tauri/src/lib.rs` registers these commands for desktop IPC while `src-tauri/src/bin/server.rs` does not expose matching `/api/*` routes.
+
+## Constraints
+
+- Preserve the existing browser command contract from `src/lib/backend.ts`, which posts JSON to `/api/<command>`.
+- Reuse the existing Rust command behavior instead of re-implementing deploy or keybinding logic in the server binary.
+- Keep server-mode parity maintainable so future desktop commands do not silently drift away from the Axum route table.
+- Follow repo workflow: test-first, then implementation, then full verification (`pnpm check`, `cargo fmt --check`, `cargo clippy -- -D warnings`).
+
+## Approach
+
+1. Add a server regression test that parses the desktop invoke list and server route table from source and compares them.
+2. Allow only explicitly intentional server-only routes in the parity test.
+3. Add the missing Axum routes and handlers for:
+   - `detect_project_type`
+   - `get_deploy_credentials`
+   - `save_deploy_credentials`
+   - `is_deploy_provisioned`
+   - `deploy_project`
+   - `list_deployed_services`
+   - `load_keybindings`
+4. Implement handlers as thin wrappers around the existing library commands.
+
+## Validation
+
+- The new parity test must fail before the route additions and pass after them.
+- A targeted Cargo test run must cover the parity regression.
+- Repo verification gates must pass after the change.

--- a/docs/plans/2026-03-17-server-api-parity.md
+++ b/docs/plans/2026-03-17-server-api-parity.md
@@ -1,0 +1,95 @@
+# Server API Parity Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Expose the missing deploy and keybinding server-mode API routes and add a parity regression test so browser mode stays aligned with the desktop command surface.
+
+**Architecture:** The Axum server remains a thin transport layer over the shared library commands. A source-based regression test compares the Tauri invoke registration in `src-tauri/src/lib.rs` with the server route table in `src-tauri/src/bin/server.rs`, with a narrow allowlist for intentional server-only routes.
+
+**Tech Stack:** Rust, Tauri v2 command library, Axum, serde_json, Cargo tests
+
+---
+
+### Task 1: Add the failing parity regression test
+
+**Files:**
+- Modify: `src-tauri/src/bin/server.rs`
+- Test: `src-tauri/src/bin/server.rs`
+
+**Step 1: Write the failing test**
+
+Add a test that:
+- reads `src/lib.rs`
+- extracts `commands::...` and `deploy::commands::...` names from `tauri::generate_handler![...]`
+- reads `src/bin/server.rs`
+- extracts `/api/<command>` route names
+- asserts that server routes include the desktop commands, except for a tiny explicit allowlist of server-only routes
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test --features server server_routes_cover_desktop_command_surface`
+
+Expected: FAIL with the current missing deploy/keybinding route names in the diff
+
+**Step 3: Commit**
+
+Do not commit yet. Continue to Task 2 after the red state is confirmed.
+
+### Task 2: Implement the missing server handlers and routes
+
+**Files:**
+- Modify: `src-tauri/src/bin/server.rs`
+- Reference: `src-tauri/src/deploy/commands.rs`
+- Reference: `src-tauri/src/commands.rs`
+
+**Step 1: Write minimal implementation**
+
+Add Axum routes and wrapper handlers for:
+- `detect_project_type`
+- `get_deploy_credentials`
+- `save_deploy_credentials`
+- `is_deploy_provisioned`
+- `deploy_project`
+- `list_deployed_services`
+- `load_keybindings`
+
+Each handler should deserialize the expected JSON payload shape and delegate to the existing library command function or helper.
+
+**Step 2: Run targeted test to verify it passes**
+
+Run: `cd src-tauri && cargo test --features server server_routes_cover_desktop_command_surface`
+
+Expected: PASS
+
+### Task 3: Full verification and review
+
+**Files:**
+- Modify: `src-tauri/src/bin/server.rs`
+- Create: `docs/plans/2026-03-17-server-api-parity-design.md`
+- Create: `docs/plans/2026-03-17-server-api-parity.md`
+
+**Step 1: Run repo verification**
+
+Run:
+- `pnpm check`
+- `cd src-tauri && cargo fmt --check`
+- `cd src-tauri && cargo clippy --features server -- -D warnings`
+
+**Step 2: Self-review**
+
+Inspect the diff for:
+- exact route parity
+- no duplicated deploy logic
+- no extra behavior changes
+
+**Step 3: Commit**
+
+Use a Conventional Commit message that includes `closes #14` and the required trailer:
+
+```text
+fix: expose server deploy and keybinding routes
+
+closes #14
+
+Contributed-by: auto-worker
+```

--- a/src-tauri/src/bin/server.rs
+++ b/src-tauri/src/bin/server.rs
@@ -15,9 +15,9 @@ use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
 use the_controller_lib::{
-    architecture, auto_worker, commands, config, emitter::WsBroadcastEmitter, maintainer, models,
-    note_ai_chat, notes, secure_env, session_args, state::AppState, status_socket, token_usage,
-    worktree::WorktreeManager,
+    architecture, auto_worker, commands, config, deploy, emitter::WsBroadcastEmitter, maintainer,
+    models, note_ai_chat, notes, secure_env, session_args, state::AppState, status_socket,
+    token_usage, worktree::WorktreeManager,
 };
 
 use tokio::sync::broadcast;
@@ -120,6 +120,16 @@ async fn main() {
         .route("/api/home_dir", post(home_dir))
         .route("/api/save_onboarding_config", post(save_onboarding_config))
         .route("/api/log_frontend_error", post(log_frontend_error))
+        .route("/api/detect_project_type", post(detect_project_type))
+        .route("/api/get_deploy_credentials", post(get_deploy_credentials))
+        .route(
+            "/api/save_deploy_credentials",
+            post(save_deploy_credentials),
+        )
+        .route("/api/is_deploy_provisioned", post(is_deploy_provisioned))
+        .route("/api/deploy_project", post(deploy_project))
+        .route("/api/list_deployed_services", post(list_deployed_services))
+        .route("/api/load_keybindings", post(load_keybindings))
         .route(
             "/api/copy_image_file_to_clipboard",
             post(copy_image_file_to_clipboard),
@@ -1048,6 +1058,72 @@ async fn log_frontend_error(
 
     tracing::error!(target: "frontend", "{}", sanitized);
     Ok(Json(Value::Null))
+}
+
+async fn detect_project_type(Json(args): Json<Value>) -> Result<Json<Value>, (StatusCode, String)> {
+    let repo_path = args["repoPath"]
+        .as_str()
+        .ok_or_else(|| (StatusCode::BAD_REQUEST, "missing repoPath".to_string()))?
+        .to_string();
+    let result = deploy::commands::detect_project_type(repo_path)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(serde_json::to_value(result).unwrap()))
+}
+
+async fn get_deploy_credentials() -> Result<Json<Value>, (StatusCode, String)> {
+    let result = deploy::commands::get_deploy_credentials()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(serde_json::to_value(result).unwrap()))
+}
+
+async fn save_deploy_credentials(
+    Json(args): Json<Value>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let credentials: deploy::credentials::DeployCredentials =
+        serde_json::from_value(args["credentials"].clone())
+            .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+    deploy::commands::save_deploy_credentials(credentials)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(Value::Null))
+}
+
+async fn is_deploy_provisioned() -> Result<Json<Value>, (StatusCode, String)> {
+    let provisioned = deploy::commands::is_deploy_provisioned()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(Value::Bool(provisioned)))
+}
+
+async fn deploy_project(Json(args): Json<Value>) -> Result<Json<Value>, (StatusCode, String)> {
+    let request: deploy::commands::DeployRequest = serde_json::from_value(args["request"].clone())
+        .map_err(|e| (StatusCode::BAD_REQUEST, e.to_string()))?;
+    let result = deploy::commands::deploy_project(request)
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(serde_json::to_value(result).unwrap()))
+}
+
+async fn list_deployed_services() -> Result<Json<Value>, (StatusCode, String)> {
+    let services = deploy::commands::list_deployed_services()
+        .await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e))?;
+    Ok(Json(Value::Array(services)))
+}
+
+async fn load_keybindings(
+    AxumState(state): AxumState<Arc<ServerState>>,
+) -> Result<Json<Value>, (StatusCode, String)> {
+    let base_dir = state
+        .app
+        .storage
+        .lock()
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, e.to_string()))?
+        .base_dir();
+    let result = the_controller_lib::keybindings::load_keybindings(&base_dir);
+    Ok(Json(serde_json::to_value(result).unwrap()))
 }
 
 // --- Desktop-only stubs (return NOT_IMPLEMENTED gracefully) ---
@@ -3005,5 +3081,82 @@ async fn handle_ws(mut socket: WebSocket, mut rx: broadcast::Receiver<String>) {
         if socket.send(Message::Text(msg.into())).await.is_err() {
             break;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeSet;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn source_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src")
+    }
+
+    fn extract_desktop_commands(source: &str) -> BTreeSet<String> {
+        let invoke_list = source
+            .split("tauri::generate_handler![")
+            .nth(1)
+            .and_then(|section| section.split("])").next())
+            .expect("desktop invoke handler list should exist");
+
+        invoke_list
+            .lines()
+            .filter_map(|line| {
+                let trimmed = line.trim().trim_end_matches(',');
+                trimmed
+                    .strip_prefix("commands::")
+                    .or_else(|| trimmed.strip_prefix("deploy::commands::"))
+                    .map(ToOwned::to_owned)
+            })
+            .collect()
+    }
+
+    fn extract_server_routes(source: &str) -> BTreeSet<String> {
+        source
+            .split(".route(")
+            .skip(1)
+            .filter_map(|segment| {
+                let start = segment.find('"')?;
+                let after_quote = &segment[start + 1..];
+                let end = after_quote.find('"')?;
+                let path = &after_quote[..end];
+                path.strip_prefix("/api/").map(ToOwned::to_owned)
+            })
+            .collect()
+    }
+
+    #[test]
+    fn server_routes_cover_desktop_command_surface() {
+        let root = source_root();
+        let lib_rs = fs::read_to_string(root.join("lib.rs")).expect("should read lib.rs");
+        let server_rs =
+            fs::read_to_string(root.join("bin/server.rs")).expect("should read server.rs");
+
+        let desktop_commands = extract_desktop_commands(&lib_rs);
+        let server_routes = extract_server_routes(&server_rs);
+        let allowed_server_only = BTreeSet::from([String::from("list_archived_projects")]);
+
+        let missing: Vec<_> = desktop_commands
+            .difference(&server_routes)
+            .cloned()
+            .collect();
+        let unexpected_server_only: Vec<_> = server_routes
+            .difference(&desktop_commands)
+            .filter(|name| !allowed_server_only.contains(*name))
+            .cloned()
+            .collect();
+
+        assert!(
+            missing.is_empty(),
+            "server router is missing desktop commands: {:?}",
+            missing
+        );
+        assert!(
+            unexpected_server_only.is_empty(),
+            "server router has unexpected command routes: {:?}",
+            unexpected_server_only
+        );
     }
 }


### PR DESCRIPTION
## Summary
- expose the missing deploy and keybinding API endpoints in server mode
- add a parity regression test comparing the desktop invoke surface with the Axum route table
- document the design and implementation plan for the change

closes #14