### PR TITLE
fix: harden deploy credential file permissions

### DIFF
--- a/docs/plans/2026-03-17-deploy-credentials-permissions-design.md
+++ b/docs/plans/2026-03-17-deploy-credentials-permissions-design.md
@@ -1,0 +1,56 @@
+# Deploy Credentials Permissions Design
+
+## Summary
+
+Tighten deploy credential persistence so `~/.the-controller/deploy-credentials.json` is created and kept with owner-only permissions on Unix. This removes reliance on process `umask` for a file that stores long-lived infrastructure API keys.
+
+## Goals
+
+- Create the deploy credentials file with explicit `0600` permissions on Unix.
+- Preserve `0600` permissions when the file is updated.
+- Keep the existing JSON format and public `DeployCredentials` API unchanged.
+
+## Non-Goals
+
+- Moving secrets into the OS keychain.
+- Changing the credential file location or schema.
+- Introducing platform-specific behavior outside the Unix permission hardening already required by the issue.
+
+## Approach Options
+
+### Option 1: Keep `std::fs::write` and chmod after write
+
+Pros:
+
+- Minimal code churn.
+
+Cons:
+
+- Leaves a create-time window where the file mode is derived from `umask`.
+- Does not satisfy the issue’s requirement to create the file with explicit restrictive permissions.
+
+### Option 2: Use `OpenOptions` and set the Unix create mode at file creation time
+
+Pros:
+
+- Creates the file with explicit `0600` permissions on Unix.
+- Works for both initial writes and later updates with a single code path.
+- Keeps the implementation local to `deploy/credentials.rs`.
+
+Cons:
+
+- Slightly more code than `std::fs::write`.
+
+Recommendation: Option 2.
+
+## Design
+
+Replace the raw `std::fs::write` call with a small helper that opens the credentials file for write, create, and truncate. On Unix, configure the open call with mode `0o600` so newly created files start restrictive. After writing, continue applying `set_permissions(0o600)` so existing files are corrected if they were created earlier with broader access.
+
+Testing will use a temp `HOME` directory and a Unix-only regression test that:
+
+1. Saves credentials and asserts the file mode is `0600`.
+2. Manually broadens the mode to simulate a previously insecure file.
+3. Saves again and asserts the mode returns to `0600`.
+
+This test covers both creation-time hardening and update-time preservation.

--- a/docs/plans/2026-03-17-deploy-credentials-permissions.md
+++ b/docs/plans/2026-03-17-deploy-credentials-permissions.md
@@ -1,0 +1,73 @@
+# Deploy Credentials Permissions Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Ensure deploy credentials are persisted with restrictive owner-only file permissions on Unix.
+
+**Architecture:** Keep the change inside `src-tauri/src/deploy/credentials.rs`. Add a Unix-only regression test around file permissions first, then replace the write path with an explicit open-and-write flow that sets `0600` at creation time and re-applies it after updates.
+
+**Tech Stack:** Rust, serde, tempfile, Unix file permissions
+
+---
+
+### Task 1: Add the Unix regression test
+
+**Files:**
+- Modify: `src-tauri/src/deploy/credentials.rs`
+- Test: `src-tauri/src/deploy/credentials.rs`
+
+**Step 1: Write the failing test**
+
+Add a Unix-only test that:
+- sets `HOME` to a temp directory
+- saves `DeployCredentials`
+- asserts `~/.the-controller/deploy-credentials.json` exists with mode `0o600`
+- broadens the mode to `0o644`
+- saves again
+- asserts the mode is back to `0o600`
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test deploy::credentials::tests::save_sets_owner_only_permissions_on_unix`
+Expected: FAIL because the current implementation creates the file through `std::fs::write`, which does not specify restrictive create-time permissions.
+
+**Step 3: Write minimal implementation**
+
+Replace the save path with an explicit file open/write helper that sets mode `0o600` on Unix and preserves `0o600` after updates.
+
+**Step 4: Run test to verify it passes**
+
+Run: `cd src-tauri && cargo test deploy::credentials::tests::save_sets_owner_only_permissions_on_unix`
+Expected: PASS
+
+**Step 5: Commit**
+
+```bash
+git add docs/plans/2026-03-17-deploy-credentials-permissions-design.md docs/plans/2026-03-17-deploy-credentials-permissions.md src-tauri/src/deploy/credentials.rs
+git commit -m "fix: harden deploy credential file permissions"
+```
+
+### Task 2: Run repository verification gates
+
+**Files:**
+- Verify only: `src-tauri/src/deploy/credentials.rs`
+
+**Step 1: Run frontend gate**
+
+Run: `pnpm check`
+Expected: PASS
+
+**Step 2: Run Rust formatting gate**
+
+Run: `cd src-tauri && cargo fmt --check`
+Expected: PASS
+
+**Step 3: Run Rust lint gate**
+
+Run: `cd src-tauri && cargo clippy -- -D warnings`
+Expected: PASS
+
+**Step 4: Run Rust tests**
+
+Run: `cd src-tauri && cargo test`
+Expected: PASS

--- a/src-tauri/src/deploy/credentials.rs
+++ b/src-tauri/src/deploy/credentials.rs
@@ -1,4 +1,7 @@
 use serde::{Deserialize, Serialize};
+use std::fs::{File, OpenOptions};
+use std::io::Write;
+use std::path::Path;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -44,7 +47,8 @@ impl DeployCredentials {
             std::fs::create_dir_all(parent).map_err(|e| e.to_string())?;
         }
         let data = serde_json::to_string_pretty(self).map_err(|e| e.to_string())?;
-        std::fs::write(&path, data).map_err(|e| e.to_string())?;
+        let mut file = open_credentials_file(&path).map_err(|e| e.to_string())?;
+        file.write_all(data.as_bytes()).map_err(|e| e.to_string())?;
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -55,9 +59,31 @@ impl DeployCredentials {
     }
 }
 
+fn open_credentials_file(path: &Path) -> std::io::Result<File> {
+    let mut options = OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600);
+    }
+
+    options.open(path)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use once_cell::sync::Lazy;
+    use std::env;
+    use std::fs;
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+    use std::sync::Mutex;
+    use tempfile::TempDir;
+
+    static ENV_LOCK: Lazy<Mutex<()>> = Lazy::new(|| Mutex::new(()));
 
     #[test]
     fn test_default_credentials_are_not_provisioned() {
@@ -97,5 +123,64 @@ mod tests {
         let json = serde_json::to_string(&creds).unwrap();
         let deserialized: DeployCredentials = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.hetzner_api_key, Some("test-key".into()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_open_credentials_file_creates_owner_only_file_on_unix() {
+        let tmp = TempDir::new().expect("temp dir");
+        let path = tmp.path().join("deploy-credentials.json");
+        let original_umask = unsafe { libc::umask(0) };
+
+        let file = open_credentials_file(&path).expect("open credentials file");
+
+        unsafe {
+            libc::umask(original_umask);
+        }
+
+        drop(file);
+
+        let mode = fs::metadata(&path)
+            .expect("stat credentials file")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_save_restores_owner_only_permissions_on_unix() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let tmp = TempDir::new().expect("temp dir");
+        let original_home = env::var_os("HOME");
+        env::set_var("HOME", tmp.path());
+
+        let creds = DeployCredentials {
+            hetzner_api_key: Some("test-key".into()),
+            ..Default::default()
+        };
+
+        creds.save().expect("initial save");
+
+        let path = DeployCredentials::config_path();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).expect("broaden permissions");
+
+        creds.save().expect("second save");
+
+        let mode = fs::metadata(&path)
+            .expect("stat credentials file")
+            .permissions()
+            .mode()
+            & 0o777;
+
+        match original_home {
+            Some(home) => env::set_var("HOME", home),
+            None => env::remove_var("HOME"),
+        }
+
+        assert_eq!(mode, 0o600);
     }
 }


### PR DESCRIPTION
## Summary
- create deploy credential files with explicit owner-only permissions on Unix instead of relying on `std::fs::write`
- keep correcting existing credential files back to `0600` on save
- add Unix regression coverage for both create-time and update-time permissions

closes #20
