### PR TITLE
fix: stop printing server auth tokens

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -152,11 +152,10 @@ echo ""
 echo "==> Deployment complete!"
 if [[ -n "$HOST" ]] && command -v caddy &>/dev/null; then
   echo "    URL: https://$HOST"
-  echo "    Token: $TOKEN"
 else
   echo "    URL: http://localhost:$PORT"
-  echo "    Token: $TOKEN"
 fi
+echo "    Auth token: read CONTROLLER_AUTH_TOKEN in $ENV_FILE"
 echo ""
 echo "    Manage:  systemctl --user {start|stop|restart|status} the-controller"
 echo "    Logs:    journalctl --user -u the-controller -f"

--- a/docs/plans/2026-03-17-server-auth-token-stdout-design.md
+++ b/docs/plans/2026-03-17-server-auth-token-stdout-design.md
@@ -1,0 +1,29 @@
+# Server Auth Token Stdout Design
+
+## Definition
+
+Issue `#19` is a credential leak in server mode. When `CONTROLLER_AUTH_TOKEN` is set, the server startup path prints a full `http://...?...token=...` URL to stdout, which is then persisted by the user-level systemd service into the journal. The goal is to stop emitting the raw token to stdout while keeping startup feedback useful for operators.
+
+## Constraints
+
+- Do not weaken existing auth behavior for `/api/*` and `/ws`.
+- Keep startup logging informative enough for local operators to know where the server is listening.
+- Follow TDD: add a regression test that fails before the fix and passes after it.
+- Prefer a minimal change in `src-tauri/src/bin/server.rs`; harden any other obvious stdout leak only if it does not expand scope materially.
+- Preserve existing repo conventions and run all required validation gates before merge.
+
+## Approach
+
+1. Extract the startup announcement into a small helper in `src-tauri/src/bin/server.rs`.
+2. Add a unit test that proves authenticated mode never includes the raw token in the stdout-facing message.
+3. Change the startup path to print a sanitized operator message without the secret and keep structured logs redacted.
+4. Remove the deploy script's final token echo so the same credential is not exposed during deploy completion output.
+
+## Validation
+
+- Unit test in `src-tauri/src/bin/server.rs` fails against the old implementation because the raw token appears in the startup message.
+- The same test passes after the fix.
+- `pnpm check`
+- `cd src-tauri && cargo fmt --check`
+- `cd src-tauri && cargo clippy --features server --bin server -- -D warnings`
+- Focused Rust test run for the new regression coverage, plus the repo-required gates above.

--- a/docs/plans/2026-03-17-server-auth-token-stdout.md
+++ b/docs/plans/2026-03-17-server-auth-token-stdout.md
@@ -1,0 +1,90 @@
+# Server Auth Token Stdout Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use executing-plans to implement this plan task-by-task.
+
+**Goal:** Stop printing the server auth token to stdout while preserving usable startup messaging and regression coverage.
+
+**Architecture:** Keep the change local to the server binary by routing startup messaging through a helper that can be unit tested. In authenticated mode, stdout should only mention the listening address and where to find the token, never the token value itself. The deploy script should stop echoing the same token during completion output.
+
+**Tech Stack:** Rust, Axum server binary, Bash deploy script, cargo tests
+
+---
+
+### Task 1: Add the failing regression test
+
+**Files:**
+- Modify: `src-tauri/src/bin/server.rs`
+- Test: `src-tauri/src/bin/server.rs`
+
+**Step 1: Write the failing test**
+
+Add a unit test around a startup-message helper so authenticated mode asserts:
+- the raw token string is absent
+- the address remains present
+- the message tells the operator to read the token from config instead of stdout
+
+**Step 2: Run test to verify it fails**
+
+Run: `cd src-tauri && cargo test --features server --bin server authenticated_startup_message_does_not_print_raw_token`
+
+Expected: FAIL because the current startup path still embeds the raw token in the message.
+
+### Task 2: Implement the minimal fix
+
+**Files:**
+- Modify: `src-tauri/src/bin/server.rs`
+
+**Step 1: Add a startup-message helper**
+
+Return:
+- a stdout-safe message for operators
+- a redacted structured-log message for tracing
+
+**Step 2: Update startup logging**
+
+Replace the inline `println!` and `tracing::info!` token formatting with the helper output.
+
+**Step 3: Run the focused test**
+
+Run: `cd src-tauri && cargo test --features server --bin server authenticated_startup_message_does_not_print_raw_token`
+
+Expected: PASS
+
+### Task 3: Remove the deploy script token echo
+
+**Files:**
+- Modify: `deploy/deploy.sh`
+
+**Step 1: Update the completion output**
+
+Print the URL and config path, but do not echo `CONTROLLER_AUTH_TOKEN`.
+
+**Step 2: Keep operator guidance intact**
+
+Tell operators to read the token from `$ENV_FILE` instead of printing it.
+
+### Task 4: Verify, review, and ship
+
+**Files:**
+- Modify: `docs/plans/2026-03-17-server-auth-token-stdout-design.md`
+- Modify: `docs/plans/2026-03-17-server-auth-token-stdout.md`
+- Modify: `src-tauri/src/bin/server.rs`
+- Modify: `deploy/deploy.sh`
+
+**Step 1: Run repo validation**
+
+Run:
+- `cd src-tauri && cargo test --features server --bin server authenticated_startup_message_does_not_print_raw_token`
+- `pnpm check`
+- `cd src-tauri && cargo fmt --check`
+- `cd src-tauri && cargo clippy --features server --bin server -- -D warnings`
+
+**Step 2: Review the diff**
+
+Confirm no raw auth token is printed to stdout or logs by the changed paths.
+
+**Step 3: Commit**
+
+Use a conventional commit and include:
+- `closes #19`
+- `Contributed-by: auto-worker`

--- a/src-tauri/src/bin/server.rs
+++ b/src-tauri/src/bin/server.rs
@@ -40,6 +40,21 @@ fn get_bind_address() -> String {
     std::env::var("CONTROLLER_BIND").unwrap_or_else(|_| "0.0.0.0".to_string())
 }
 
+fn startup_messages(addr: &str, token: Option<&str>) -> (Option<String>, String) {
+    match token.filter(|t| !t.is_empty()) {
+        Some(_) => {
+            (
+                Some(format!(
+                    "Server listening on http://{} (auth enabled; read CONTROLLER_AUTH_TOKEN from ~/.the-controller/server.env)",
+                    addr
+                )),
+                format!("server listening on http://{} (auth enabled)", addr),
+            )
+        }
+        None => (None, format!("server listening on http://{} (no auth)", addr)),
+    }
+}
+
 async fn shutdown_signal(state: Arc<ServerState>) {
     let ctrl_c = async { tokio::signal::ctrl_c().await.unwrap() };
 
@@ -229,15 +244,11 @@ async fn main() {
     let token = std::env::var("CONTROLLER_AUTH_TOKEN")
         .ok()
         .filter(|t| !t.is_empty());
-    match &token {
-        Some(t) => {
-            // Print token to stdout (ephemeral) — don't persist it in log files
-            let masked = format!("{}***", &t[..4.min(t.len())]);
-            println!("Server listening on http://{}?token={}", addr, t);
-            tracing::info!("server listening on http://{} (token: {})", addr, masked);
-        }
-        None => tracing::info!("server listening on http://{} (no auth)", addr),
+    let (stdout_message, log_message) = startup_messages(&addr, token.as_deref());
+    if let Some(message) = stdout_message {
+        println!("{}", message);
     }
+    tracing::info!("{}", log_message);
     let listener = tokio::net::TcpListener::bind(&addr).await.unwrap();
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(state))
@@ -3136,6 +3147,7 @@ async fn handle_ws(mut socket: WebSocket, mut rx: broadcast::Receiver<String>) {
 
 #[cfg(test)]
 mod tests {
+    use crate::startup_messages;
     use std::collections::BTreeSet;
     use std::fs;
     use std::path::PathBuf;
@@ -3208,5 +3220,27 @@ mod tests {
             "server router has unexpected command routes: {:?}",
             unexpected_server_only
         );
+    }
+
+    #[test]
+    fn authenticated_startup_message_does_not_print_raw_token() {
+        let addr = "127.0.0.1:3001";
+        let token = "super-secret-token";
+
+        let (stdout_message, log_message) = startup_messages(addr, Some(token));
+
+        let stdout_message = stdout_message.expect("authenticated startup should print guidance");
+        assert!(stdout_message.contains(addr));
+        assert!(
+            !stdout_message.contains(token),
+            "stdout should not contain raw auth token"
+        );
+        assert!(
+            stdout_message.contains("server.env"),
+            "stdout should direct operators to the config file"
+        );
+
+        assert!(log_message.contains(addr));
+        assert!(!log_message.contains(token));
     }
 }


### PR DESCRIPTION
## Summary
- stop printing the server auth token in authenticated server startup output
- add a regression test for sanitized startup messaging
- stop echoing the deploy token in deploy completion output

closes #19