### PR TITLE
fix: comprehensive code review fixes across 25 modules

### DIFF
--- a/src-tauri/src/broker_client.rs
+++ b/src-tauri/src/broker_client.rs
@@ -144,7 +144,10 @@ impl BrokerClient {
         let start = std::time::Instant::now();
         let poll_interval = std::time::Duration::from_millis(50);
         while start.elapsed() < timeout {
-            let alive = unsafe { libc::kill(pid, 0) } == 0;
+            let ret = unsafe { libc::kill(pid, 0) };
+            let alive = ret == 0
+                || (ret == -1
+                    && std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM));
             if !alive {
                 tracing::debug!(
                     pid,
@@ -168,7 +171,10 @@ impl BrokerClient {
         let pid_path = self.pid_file_path();
         if let Ok(contents) = std::fs::read_to_string(&pid_path) {
             if let Ok(pid) = contents.trim().parse::<i32>() {
-                let alive = unsafe { libc::kill(pid, 0) } == 0;
+                let ret = unsafe { libc::kill(pid, 0) };
+                let alive = ret == 0
+                    || (ret == -1
+                        && std::io::Error::last_os_error().raw_os_error() == Some(libc::EPERM));
                 if !alive {
                     tracing::debug!(pid, "cleaning up stale PID file and control socket");
                     let _ = std::fs::remove_file(&pid_path);

--- a/src-tauri/src/config.rs
+++ b/src-tauri/src/config.rs
@@ -48,7 +48,10 @@ pub fn save_config(base_dir: &Path, config: &Config) -> std::io::Result<()> {
     fs::create_dir_all(base_dir)?;
     let json = serde_json::to_string_pretty(config)
         .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-    fs::write(config_path(base_dir), json)
+    let dest = config_path(base_dir);
+    let tmp = dest.with_extension("json.tmp");
+    fs::write(&tmp, json)?;
+    fs::rename(&tmp, &dest)
 }
 
 /// Checks if the claude CLI is installed and authenticated.

--- a/src-tauri/src/deploy/credentials.rs
+++ b/src-tauri/src/deploy/credentials.rs
@@ -19,6 +19,7 @@ impl DeployCredentials {
     pub fn is_provisioned(&self) -> bool {
         let provisioned = self.hetzner_api_key.is_some()
             && self.cloudflare_api_key.is_some()
+            && self.cloudflare_zone_id.is_some()
             && self.root_domain.is_some()
             && self.coolify_url.is_some()
             && self.coolify_api_key.is_some()
@@ -27,6 +28,7 @@ impl DeployCredentials {
             let missing: Vec<&str> = [
                 ("hetzner_api_key", &self.hetzner_api_key),
                 ("cloudflare_api_key", &self.cloudflare_api_key),
+                ("cloudflare_zone_id", &self.cloudflare_zone_id),
                 ("root_domain", &self.root_domain),
                 ("coolify_url", &self.coolify_url),
                 ("coolify_api_key", &self.coolify_api_key),

--- a/src-tauri/src/maintainer.rs
+++ b/src-tauri/src/maintainer.rs
@@ -179,7 +179,8 @@ impl MaintainerScheduler {
                         continue;
                     }
 
-                    let interval = Duration::from_secs(project.maintainer.interval_minutes * 60);
+                    let interval_mins = project.maintainer.interval_minutes.max(1);
+                    let interval = Duration::from_secs(interval_mins * 60);
                     let should_run = last_run
                         .get(&project.id)
                         .is_none_or(|t| t.elapsed() >= interval);
@@ -336,11 +337,10 @@ fn parse_findings_output(output: &str) -> Result<FindingsOutput, String> {
 
     let mut findings = Vec::with_capacity(raw.findings.len());
     for (idx, finding) in raw.findings.into_iter().enumerate() {
-        let sanitized = sanitize_finding(finding).ok_or_else(|| {
-            tracing::warn!(index = idx, "invalid finding dropped during sanitization");
-            format!("Invalid finding at index {}", idx)
-        })?;
-        findings.push(sanitized);
+        match sanitize_finding(finding) {
+            Some(sanitized) => findings.push(sanitized),
+            None => tracing::warn!(index = idx, "invalid finding dropped during sanitization"),
+        }
     }
 
     Ok(FindingsOutput {
@@ -1364,6 +1364,7 @@ mod tests {
 
     #[test]
     fn test_parse_findings_output_invalid_finding_returns_error() {
+        // An empty-title finding is dropped silently rather than aborting the whole batch
         let output = r#"{
           "findings": [
             {
@@ -1380,7 +1381,8 @@ mod tests {
         }"#;
 
         let parsed = parse_findings_output(output);
-        assert!(parsed.is_err());
+        assert!(parsed.is_ok());
+        assert!(parsed.unwrap().findings.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/pty_manager.rs
+++ b/src-tauri/src/pty_manager.rs
@@ -102,6 +102,7 @@ impl PtyManager {
             working_dir,
             command,
             emitter,
+            continue_session,
             initial_prompt,
             rows,
             cols,
@@ -224,6 +225,7 @@ impl PtyManager {
         working_dir: &str,
         command: &str,
         emitter: Arc<dyn EventEmitter>,
+        continue_session: bool,
         initial_prompt: Option<&str>,
         rows: u16,
         cols: u16,
@@ -250,9 +252,12 @@ impl PtyManager {
         if let Some(path_val) = crate::cli_install::path_with_controller_bin() {
             cmd.env("PATH", path_val);
         }
-        for arg in
-            crate::session_args::build_session_args(command, session_id, false, initial_prompt)
-        {
+        for arg in crate::session_args::build_session_args(
+            command,
+            session_id,
+            continue_session,
+            initial_prompt,
+        ) {
             cmd.arg(arg);
         }
 

--- a/src-tauri/src/secure_env.rs
+++ b/src-tauri/src/secure_env.rs
@@ -340,10 +340,11 @@ pub fn update_env_file(env_path: &Path, key: &str, value: &str) -> Result<EnvWri
     let mut replaced = false;
     let mut lines = Vec::new();
     for line in existing.lines() {
-        if line
-            .strip_prefix(key)
-            .and_then(|rest| rest.strip_prefix('='))
-            .is_some()
+        if !replaced
+            && line
+                .strip_prefix(key)
+                .and_then(|rest| rest.strip_prefix('='))
+                .is_some()
         {
             lines.push(format!("{key}={value}"));
             replaced = true;

--- a/src-tauri/src/service/deploy.rs
+++ b/src-tauri/src/service/deploy.rs
@@ -74,8 +74,14 @@ pub async fn deploy_project(request: DeployRequest) -> Result<DeployResult, AppE
     }
 
     let coolify = CoolifyClient::new(
-        creds.coolify_url.as_ref().unwrap(),
-        creds.coolify_api_key.as_ref().unwrap(),
+        creds
+            .coolify_url
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("Coolify URL not configured".to_string()))?,
+        creds
+            .coolify_api_key
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("Coolify API key not configured".to_string()))?,
     );
 
     let apps = coolify
@@ -98,7 +104,11 @@ pub async fn deploy_project(request: DeployRequest) -> Result<DeployResult, AppE
         ));
     };
 
-    let domain = format!("{}.{}", request.subdomain, creds.root_domain.unwrap());
+    let root_domain = creds
+        .root_domain
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Root domain not configured".to_string()))?;
+    let domain = format!("{}.{}", request.subdomain, root_domain);
     let url = format!("https://{domain}");
 
     tracing::info!(url = %url, uuid = %uuid, "deployment complete");
@@ -121,8 +131,14 @@ pub async fn list_deployed_services() -> Result<Vec<serde_json::Value>, AppError
     }
 
     let coolify = CoolifyClient::new(
-        creds.coolify_url.as_ref().unwrap(),
-        creds.coolify_api_key.as_ref().unwrap(),
+        creds
+            .coolify_url
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("Coolify URL not configured".to_string()))?,
+        creds
+            .coolify_api_key
+            .as_ref()
+            .ok_or_else(|| AppError::Internal("Coolify API key not configured".to_string()))?,
     );
 
     let apps = coolify

--- a/src-tauri/src/service/sessions.rs
+++ b/src-tauri/src/service/sessions.rs
@@ -67,6 +67,10 @@ pub(crate) fn find_staging_port(base_port: u16) -> Result<u16, String> {
 /// Kill a process group by PID. Sends SIGTERM to the group, then SIGKILL after 2s
 /// if the group is still alive.
 pub fn kill_process_group(pid: u32) {
+    if pid == 0 {
+        tracing::warn!("refusing to kill process group 0 (would kill own process group)");
+        return;
+    }
     tracing::debug!(pid, "killing process group");
     #[cfg(unix)]
     {
@@ -161,6 +165,11 @@ pub fn connect_session(
     };
 
     let mut mgr = pty_manager.lock().map_err(AppError::internal)?;
+    // Definitive check under lock to prevent double-spawn race (TOCTOU)
+    if mgr.sessions.contains_key(&session_id) {
+        tracing::debug!(session_id = %session_id, "session connected by concurrent request, skipping");
+        return Ok(());
+    }
     mgr.spawn_session(
         session_id,
         &session_dir,

--- a/src-tauri/src/skills.rs
+++ b/src-tauri/src/skills.rs
@@ -1,7 +1,11 @@
 use std::fs;
-use std::os::unix::fs::symlink;
 use std::path::{Path, PathBuf};
 use std::process::Command;
+
+#[cfg(unix)]
+use std::os::unix::fs::symlink;
+#[cfg(windows)]
+use std::os::windows::fs::symlink_dir as symlink;
 
 /// Resolve the main repo's skills directory.
 ///

--- a/src-tauri/src/storage.rs
+++ b/src-tauri/src/storage.rs
@@ -132,13 +132,19 @@ impl Storage {
     }
 
     /// Save a project's configuration to disk as `project.json`.
+    ///
+    /// Uses write-to-temp-then-rename for atomic writes, preventing corruption
+    /// if the process crashes mid-write.
     pub fn save_project(&self, project: &Project) -> std::io::Result<()> {
         tracing::debug!(project_id = %project.id, name = %project.name, "saving project");
         let dir = self.project_dir(project.id);
         fs::create_dir_all(&dir)?;
         let json = serde_json::to_string_pretty(project)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        fs::write(dir.join("project.json"), json)
+        let path = dir.join("project.json");
+        let tmp = path.with_extension("json.tmp");
+        fs::write(&tmp, json)?;
+        fs::rename(&tmp, &path)
     }
 
     /// Load a project's configuration from disk.
@@ -273,10 +279,16 @@ impl Storage {
     }
 
     /// Save agents.md content to the project's config directory.
+    ///
+    /// Uses write-to-temp-then-rename for atomic writes, preventing corruption
+    /// if the process crashes mid-write.
     pub fn save_agents_md(&self, project_id: Uuid, content: &str) -> std::io::Result<()> {
         let dir = self.project_dir(project_id);
         fs::create_dir_all(&dir)?;
-        fs::write(dir.join("agents.md"), content)
+        let path = dir.join("agents.md");
+        let tmp = path.with_extension("md.tmp");
+        fs::write(&tmp, content)?;
+        fs::rename(&tmp, &path)
     }
 
     /// Return the path to a project's maintainer run logs directory.
@@ -285,6 +297,9 @@ impl Storage {
     }
 
     /// Save a maintainer run log to disk.
+    ///
+    /// Uses write-to-temp-then-rename for atomic writes, preventing corruption
+    /// if the process crashes mid-write.
     pub fn save_maintainer_run_log(&self, log: &MaintainerRunLog) -> std::io::Result<()> {
         tracing::debug!(project_id = %log.project_id, log_id = %log.id, "saving maintainer run log");
         let dir = self.maintainer_run_logs_dir(log.project_id);
@@ -292,7 +307,10 @@ impl Storage {
         let filename = format!("{}.json", log.id);
         let json = serde_json::to_string_pretty(log)
             .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
-        fs::write(dir.join(filename), json)
+        let path = dir.join(filename);
+        let tmp = path.with_extension("json.tmp");
+        fs::write(&tmp, json)?;
+        fs::rename(&tmp, &path)
     }
 
     /// Load the most recent maintainer run log for a project.

--- a/src-tauri/src/voice/gain.rs
+++ b/src-tauri/src/voice/gain.rs
@@ -27,6 +27,10 @@ impl AutoGain {
 
     /// Process a chunk of int16 audio samples. Returns float32 in [-1.0, 1.0].
     pub fn apply(&mut self, samples: &[i16]) -> Vec<f32> {
+        if samples.is_empty() {
+            return Vec::new();
+        }
+
         // Convert to float32
         let float_samples: Vec<f32> = samples.iter().map(|&s| s as f32 / 32768.0).collect();
 

--- a/src-tauri/src/voice/mod.rs
+++ b/src-tauri/src/voice/mod.rs
@@ -162,9 +162,7 @@ impl VoicePipeline {
 
     /// Toggle pause state. Returns `true` if now paused.
     pub fn toggle_pause(&self) -> bool {
-        let was_paused = self.pause_flag.load(Ordering::SeqCst);
-        self.pause_flag.store(!was_paused, Ordering::SeqCst);
-        !was_paused
+        !self.pause_flag.fetch_xor(true, Ordering::SeqCst)
     }
 
     /// Returns `true` if the pipeline is currently paused.

--- a/src-tauri/src/voice/models.rs
+++ b/src-tauri/src/voice/models.rs
@@ -114,7 +114,10 @@ pub async fn ensure_models(
             on_progress(&filename, downloaded, total);
         }
 
-        std::fs::write(dest, &body).map_err(|e| format!("Failed to write {filename}: {e}"))?;
+        // Write to temp file then atomically rename to avoid corrupt partial downloads
+        let tmp = dest.with_extension("tmp");
+        std::fs::write(&tmp, &body).map_err(|e| format!("Failed to write {filename}: {e}"))?;
+        std::fs::rename(&tmp, dest).map_err(|e| format!("Failed to rename {filename}: {e}"))?;
     }
 
     Ok(paths)

--- a/src-tauri/src/voice/vad.rs
+++ b/src-tauri/src/voice/vad.rs
@@ -117,7 +117,14 @@ impl Vad {
             tracing::error!(error = %e, "failed to extract VAD stateN");
             format!("Failed to extract stateN: {e}")
         })?;
-        self.state = state_data.to_vec();
+        let new_state = state_data.to_vec();
+        if new_state.len() != STATE_SIZE {
+            return Err(format!(
+                "VAD state size mismatch: expected {STATE_SIZE}, got {}",
+                new_state.len()
+            ));
+        }
+        self.state = new_state;
 
         // Update context: last CONTEXT_SIZE samples from this chunk
         if chunk_len >= CONTEXT_SIZE {

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -455,7 +455,11 @@
     });
 
     let cleanupKeybindings: (() => void) | undefined;
-    initKeybindings().then((fn) => { cleanupKeybindings = fn; });
+    let keybindingsCleanedUp = false;
+    initKeybindings().then((fn) => {
+      if (keybindingsCleanedUp) fn();
+      else cleanupKeybindings = fn;
+    });
 
     void (async () => {
       updateWindowTitle(__BUILD_BRANCH__, __BUILD_COMMIT__);
@@ -478,6 +482,7 @@
 
     return () => {
       unlistenSecureEnv();
+      keybindingsCleanedUp = true;
       cleanupKeybindings?.();
     };
   });

--- a/src/lib/IssuesModal.svelte
+++ b/src/lib/IssuesModal.svelte
@@ -193,6 +193,8 @@
       if (e.key === "ArrowDown" || (!inSearch && e.key === "j")) {
         e.preventDefault();
         e.stopPropagation();
+        // Cancel close-comment mode when navigating away
+        if (closingIssue) { closingIssue = null; closeComment = ""; }
         if (filteredIssues.length > 0) {
           selectedIndex = (selectedIndex + 1) % filteredIssues.length;
           scrollSelectedIntoView();
@@ -202,6 +204,7 @@
       if (e.key === "ArrowUp" || (!inSearch && e.key === "k")) {
         e.preventDefault();
         e.stopPropagation();
+        if (closingIssue) { closingIssue = null; closeComment = ""; }
         if (filteredIssues.length > 0) {
           selectedIndex = (selectedIndex - 1 + filteredIssues.length) % filteredIssues.length;
           scrollSelectedIntoView();
@@ -223,7 +226,8 @@
         const issueToClose = closingIssue;
         allIssues = allIssues.filter(i => i.number !== issueToClose.number);
         closingIssue = null;
-        command("close_github_issue", { repoPath, issueNumber: issueToClose.number, comment: closeComment.trim() });
+        command("close_github_issue", { repoPath, issueNumber: issueToClose.number, comment: closeComment.trim() })
+          .catch(() => { allIssues = [...allIssues, issueToClose]; });
         closeComment = "";
         requestAnimationFrame(() => searchInput?.focus());
         return;
@@ -246,7 +250,8 @@
         e.stopPropagation();
         const issueToDelete = selectedIssue;
         allIssues = allIssues.filter(i => i.number !== issueToDelete.number);
-        command("delete_github_issue", { repoPath, issueNumber: issueToDelete.number });
+        command("delete_github_issue", { repoPath, issueNumber: issueToDelete.number })
+          .catch(() => { allIssues = [...allIssues, issueToDelete]; });
         return;
       }
 

--- a/src/lib/NotesEditor.svelte
+++ b/src/lib/NotesEditor.svelte
@@ -13,6 +13,7 @@
   let editorMode = $state<VimMode | string>("normal");
   let aiChatRequest = $state<AiChatRequest | null>(null);
   let assetUrlCache = $state(new Map<string, string>());
+  let pendingResolutions = new Set<string>();
 
   const activeNoteState = fromStore(activeNote);
   let currentNote = $derived(activeNoteState.current);
@@ -124,16 +125,29 @@
       saveTimer = null;
     }
     if (!currentNote || !folderName || content === savedContent) return;
+    const contentToSave = content;
+    const noteFilename = currentNote.filename;
+    const folder = folderName;
     try {
-      await command("write_note", { folder: folderName, filename: currentNote.filename, content });
-      savedContent = content;
+      await command("write_note", { folder, filename: noteFilename, content: contentToSave });
+      // Only update savedContent if we're still on the same note
+      if (currentNote?.filename === noteFilename && folderName === folder) {
+        savedContent = contentToSave;
+      }
     } catch {
       // silently fail — user will see unsaved indicator
     }
   }
 
   onDestroy(() => {
-    if (saveTimer) clearTimeout(saveTimer);
+    if (saveTimer) {
+      clearTimeout(saveTimer);
+      saveTimer = null;
+    }
+    // Flush any unsaved content
+    if (currentNote && folderName && content !== savedContent) {
+      command("write_note", { folder: folderName, filename: currentNote.filename, content }).catch(() => {});
+    }
   });
 
   function handleEditorChange(nextContent: string) {
@@ -171,8 +185,10 @@
     }
     const cached = assetUrlCache.get(relativePath);
     if (cached) return cached;
+    if (pendingResolutions.has(relativePath)) return null;
     // Trigger async resolution — the image will appear on next decoration rebuild
-    resolveImageSrc(relativePath);
+    pendingResolutions.add(relativePath);
+    resolveImageSrc(relativePath).finally(() => pendingResolutions.delete(relativePath));
     return null;
   }
 

--- a/src/lib/Sidebar.svelte
+++ b/src/lib/Sidebar.svelte
@@ -3,6 +3,11 @@
   import { command, listen } from "$lib/backend";
   import { refreshProjectsFromBackend } from "./project-listing";
   import { projects, activeSessionId, sessionStatuses, maintainerStatuses, maintainerErrors, autoWorkerStatuses, hotkeyAction, showKeyHints, focusTarget, expandedProjects, focusTerminalSoon, workspaceMode, activeNote, noteEntries, noteFolders, selectedSessionProvider, type CorruptProjectEntry, type Project, type ProjectInventory, type FocusTarget, type SessionStatus, type MaintainerStatus, type AutoWorkerStatus, type NoteEntry } from "./stores";
+
+  /** Escape a value for use in a CSS attribute selector to avoid injection. */
+  function cssSel(attr: string, value: string): string {
+    return `[${attr}="${CSS.escape(value)}"]`;
+  }
   import { showToast } from "./toast";
   import { focusAfterSessionDelete, focusAfterProjectDelete } from "./focus-helpers";
   import { sendFinishBranchPrompt } from "./finish-branch";
@@ -70,14 +75,14 @@
       }
       if (sidebarEl) {
         requestAnimationFrame(() => {
-          const el = sidebarEl?.querySelector<HTMLElement>(`[data-session-id="${focus.sessionId}"]`);
+          const el = sidebarEl?.querySelector<HTMLElement>(cssSel("data-session-id", focus.sessionId));
           if (el) el.focus();
         });
       }
     } else if (focus.type === "project") {
       if (sidebarEl) {
         requestAnimationFrame(() => {
-          const el = sidebarEl?.querySelector<HTMLElement>(`[data-project-id="${focus.projectId}"]`);
+          const el = sidebarEl?.querySelector<HTMLElement>(cssSel("data-project-id", focus.projectId));
           if (el) el.focus();
         });
       }
@@ -89,7 +94,7 @@
       }
       if (sidebarEl) {
         requestAnimationFrame(() => {
-          const el = sidebarEl?.querySelector<HTMLElement>(`[data-agent-id="${focus.projectId}:${focus.agentKind}"]`);
+          const el = sidebarEl?.querySelector<HTMLElement>(cssSel("data-agent-id", `${focus.projectId}:${focus.agentKind}`));
           if (el) el.focus();
         });
       }
@@ -101,7 +106,7 @@
     } else if (focus.type === "folder") {
       if (sidebarEl) {
         requestAnimationFrame(() => {
-          const el = sidebarEl?.querySelector<HTMLElement>(`[data-folder-id="${focus.folder}"]`);
+          const el = sidebarEl?.querySelector<HTMLElement>(cssSel("data-folder-id", focus.folder));
           if (el) el.focus();
         });
       }
@@ -113,7 +118,7 @@
       }
       if (sidebarEl) {
         requestAnimationFrame(() => {
-          const el = sidebarEl?.querySelector<HTMLElement>(`[data-note-id="${focus.folder}:${focus.filename}"]`);
+          const el = sidebarEl?.querySelector<HTMLElement>(cssSel("data-note-id", `${focus.folder}:${focus.filename}`));
           if (el) el.focus();
         });
       }

--- a/src/lib/Terminal.svelte
+++ b/src/lib/Terminal.svelte
@@ -127,7 +127,9 @@
   ]);
 
   function isImageFile(path: string): boolean {
-    const ext = path.slice(path.lastIndexOf(".")).toLowerCase();
+    const dotIndex = path.lastIndexOf(".");
+    if (dotIndex === -1) return false;
+    const ext = path.slice(dotIndex).toLowerCase();
     return IMAGE_EXTENSIONS.has(ext);
   }
 

--- a/src/lib/TerminalManager.svelte
+++ b/src/lib/TerminalManager.svelte
@@ -38,6 +38,16 @@
     projectList.flatMap((p) => p.sessions.map((s) => ({ id: s.id, kind: s.kind }))),
   );
 
+  // Clean up stale entries from terminalComponents when sessions are removed
+  $effect(() => {
+    const activeIds = new Set(allSessions.map((s) => s.id));
+    for (const id of Object.keys(terminalComponents)) {
+      if (!activeIds.has(id)) {
+        delete terminalComponents[id];
+      }
+    }
+  });
+
 </script>
 
 <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/lib/backend.ts
+++ b/src/lib/backend.ts
@@ -152,10 +152,7 @@ export async function listenAsync<T>(event: string, handler: (payload: T) => voi
       ws.addEventListener("error", () => reject(new Error("WebSocket connection failed")), { once: true });
     });
   }
-  const callback = (msg: MessageEvent) => {
-    const data = JSON.parse(msg.data);
-    if (data.event === event) handler(data.payload);
-  };
-  ws.addEventListener("message", callback);
-  return () => ws.removeEventListener("message", callback);
+  // Use listen() internally so the listener is added to wsListeners
+  // and survives WebSocket reconnects.
+  return listen<T>(event, handler);
 }

--- a/src/lib/finish-branch.ts
+++ b/src/lib/finish-branch.ts
@@ -1,4 +1,4 @@
-type SessionKind = "claude" | "codex" | "cursor-agent" | undefined;
+import type { SessionProvider } from './stores';
 
 type InvokeFn = (
   command: string,
@@ -8,7 +8,7 @@ type InvokeFn = (
 export async function sendFinishBranchPrompt(
   invoke: InvokeFn,
   sessionId: string,
-  kind: SessionKind,
+  kind: SessionProvider | undefined,
 ) {
   const isCodex = kind === "codex";
   const prompt = isCodex

--- a/src/lib/focus-helpers.ts
+++ b/src/lib/focus-helpers.ts
@@ -77,37 +77,31 @@ export function focusForModeSwitch(
       }
       return { type: "project", projectId: current.projectId };
     }
+    if (current.type === "terminal") {
+      return { type: "project", projectId: current.projectId };
+    }
   }
 
   if (newMode === "agents") {
     if (current.type === "folder" || current.type === "note" || current.type === "notes-editor") {
       return projectList[0] ? { type: "project", projectId: projectList[0].id } : null;
     }
-    if (current.type === "session") {
+    if (current.type === "session" || current.type === "terminal") {
       return { type: "project", projectId: current.projectId };
     }
   }
 
   if (newMode === "notes") {
-    if (current.type === "session" || current.type === "agent" || current.type === "agent-panel" || current.type === "project") {
+    if (current.type === "session" || current.type === "terminal" || current.type === "agent" || current.type === "agent-panel" || current.type === "project") {
       return null;
     }
   }
 
-  if (newMode === "architecture") {
+  if (newMode === "architecture" || newMode === "infrastructure") {
     if (current.type === "folder" || current.type === "note" || current.type === "notes-editor") {
       return projectList[0] ? { type: "project", projectId: projectList[0].id } : null;
     }
-    if (current.type === "session" || current.type === "agent" || current.type === "agent-panel") {
-      return { type: "project", projectId: current.projectId };
-    }
-  }
-
-  if (newMode === "infrastructure") {
-    if (current.type === "folder" || current.type === "note" || current.type === "notes-editor") {
-      return projectList[0] ? { type: "project", projectId: projectList[0].id } : null;
-    }
-    if (current.type === "session" || current.type === "agent" || current.type === "agent-panel") {
+    if (current.type === "session" || current.type === "terminal" || current.type === "agent" || current.type === "agent-panel") {
       return { type: "project", projectId: current.projectId };
     }
   }

--- a/src/lib/keybindings.ts
+++ b/src/lib/keybindings.ts
@@ -39,8 +39,8 @@ export async function initKeybindings(): Promise<() => void> {
   try {
     const result = await command<KeybindingsResult>("load_keybindings");
     applyResult(result);
-  } catch {
-    // Silently use defaults if backend call fails
+  } catch (err) {
+    console.warn("Failed to load custom keybindings, using defaults:", err);
   }
 
   return unlisten;

--- a/src/lib/stores.ts
+++ b/src/lib/stores.ts
@@ -193,6 +193,7 @@ export const selectedSessionProvider = writable<SessionProvider>("claude");
 export function sessionProviderFromConfig(
   provider: ConfigDefaultProvider | undefined,
 ): SessionProvider {
+  if (provider === "claude-code") return "claude";
   if (provider === "codex") return "codex";
   if (provider === "cursor-agent") return "cursor-agent";
   return "claude";


### PR DESCRIPTION
## Summary
- **Race conditions**: TOCTOU fix in `connect_session` (definitive check under lock before spawn), `NotesEditor` save race (capture values before await), keybinding cleanup race, `listenAsync` reconnect survival
- **Atomicity**: Atomic file writes (temp+rename) in `storage`, `config`, `voice/models`; guard `kill_process_group(0)` to prevent killing own process group
- **Error handling**: Replace `unwrap()` with proper errors in `service/deploy`, `broker_client` errno/ESRCH check, `maintainer` skip invalid findings, empty-input guard in `voice/gain`, VAD state size validation
- **Security/robustness**: CSS selector injection prevention via `CSS.escape()` in Sidebar, first-match-only `.env` key replacement, `cfg(unix)` guard for Unix-only imports
- **Frontend**: Cancel `closingIssue` on navigation in IssuesModal, error rollback for close/delete, stale terminal ref cleanup, dedup image resolution, explicit `claude-code` mapping

## Changes
25 files modified across Rust backend and Svelte frontend, found during systematic code review of all 96+ source modules over 4 review rounds.

## Test plan
- [x] All Rust tests pass (`cargo test`)
- [x] All frontend tests pass (`pnpm test` — 333 tests, 31 files)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `pnpm check` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)